### PR TITLE
[✨]ref: separated all sensor code from when expression

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/ksensor/src/commonMain/kotlin/org/kmp/shots/k/sensor/Sensor.kt
+++ b/ksensor/src/commonMain/kotlin/org/kmp/shots/k/sensor/Sensor.kt
@@ -1,6 +1,7 @@
 package org.kmp.shots.k.sensor
 
 import androidx.compose.runtime.Composable
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
@@ -51,6 +52,7 @@ internal class FakeSensorManager : SensorController {
         locationIntervalMillis: SensorTimeInterval
     ): Flow<SensorUpdate> = callbackFlow {
         registeredSensors.addAll(sensorType)
+        awaitClose { }
     }
 
     override fun unregisterSensors(types: List<SensorType>) {


### PR DESCRIPTION
Refactor sensor registration/unregistration to separate methods (Android & iOS)
Changes Resolves #4 
- [ ✅] Extracted sensor logic from when expressions: Moved complex sensor registration/unregistration logic into dedicated private methods
- [ ✅] Improved code readability: Replaced large when blocks with clean method calls
- [ ✅] Better maintainability: Each sensor type now has its own focused method
- [ ✅] Consistent architecture: Both Android and iOS now follow the same pattern