### PR TITLE
Add LocaleReceiver for Android and iOS to track locale and RTL changes

### DIFF
--- a/ksensor/src/androidMain/kotlin/org/kmp/ksensor/state/LocaleReceiver.Android.kt
+++ b/ksensor/src/androidMain/kotlin/org/kmp/ksensor/state/LocaleReceiver.Android.kt
@@ -1,0 +1,42 @@
+package org.kmp.ksensor.state
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.view.View
+import androidx.core.text.layoutDirection
+
+internal class LocaleReceiver(
+    private val context: Context,
+    val onLocaleChanged: (StateData.LocaleInfo) -> Unit
+) : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent?.action == Intent.ACTION_LOCALE_CHANGED) {
+            context?.let {
+                onLocaleChanged(getCurrentLocale())
+            }
+        }
+    }
+
+    fun getCurrentLocale(): StateData.LocaleInfo {
+        val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            context.resources.configuration.locales[0]
+        } else {
+            @Suppress("DEPRECATION")
+            context.resources.configuration.locale
+        }
+
+        // Detect RTL using Android's standard API
+        val isRtl = locale.layoutDirection == View.LAYOUT_DIRECTION_RTL
+
+        return StateData.LocaleInfo(
+            languageCode = locale.language,
+            countryCode = locale.country,
+            fullLocaleString = locale.toString(),
+            displayName = locale.displayName,
+            isRTL = isRtl
+        )
+    }
+}

--- a/ksensor/src/commonMain/kotlin/org/kmp/ksensor/state/StateData.kt
+++ b/ksensor/src/commonMain/kotlin/org/kmp/ksensor/state/StateData.kt
@@ -11,7 +11,8 @@ enum class StateType {
     CONNECTIVITY,
     ACTIVE_NETWORK,
     LOCATION,
-    VOLUME
+    VOLUME,
+    LOCALE
 }
 
 
@@ -39,5 +40,13 @@ sealed class StateData {
     data class VolumeStatus(val volumePercentage: Int): StateData()
     data class ConnectivityStatus(
         val isConnected: Boolean,
+    ) : StateData()
+
+    data class LocaleInfo(
+        val languageCode: String,      // ISO 639 (e.g., "en", "ar", "he")
+        val countryCode: String,       // ISO 3166 (e.g., "US", "SA", "IL")
+        val fullLocaleString: String,  // Complete identifier (e.g., "en_US", "ar_SA")
+        val displayName: String,       // Human-readable (e.g., "English (United States)")
+        val isRTL: Boolean             // Right-to-left layout (true for Arabic, Hebrew, etc.)
     ) : StateData()
 }

--- a/ksensor/src/iosMain/kotlin/org/kmp/ksensor/state/LocaleReceiver.iOS.kt
+++ b/ksensor/src/iosMain/kotlin/org/kmp/ksensor/state/LocaleReceiver.iOS.kt
@@ -1,0 +1,59 @@
+package org.kmp.ksensor.state
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSCurrentLocaleDidChangeNotification
+import platform.Foundation.NSLocale
+import platform.Foundation.NSLocaleIdentifier
+import platform.Foundation.NSLocaleLanguageDirectionRightToLeft
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.Foundation.characterDirectionForLanguage
+import platform.Foundation.countryCode
+import platform.Foundation.currentLocale
+import platform.Foundation.languageCode
+import platform.Foundation.localeIdentifier
+import platform.darwin.NSObject
+
+@OptIn(ExperimentalForeignApi::class)
+internal class LocaleReceiver(
+    val onLocaleChanged: (StateData.LocaleInfo) -> Unit
+) {
+    private var observer: NSObject? = null
+
+    fun registerObserver() {
+        observer = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = NSCurrentLocaleDidChangeNotification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue()
+        ) { _ ->
+            onLocaleChanged(getCurrentLocale())
+        } as NSObject?
+    }
+
+    fun removeObserver() {
+        observer?.let {
+            NSNotificationCenter.defaultCenter.removeObserver(it)
+            observer = null
+        }
+    }
+
+    fun getCurrentLocale(): StateData.LocaleInfo {
+        val locale = NSLocale.currentLocale
+        val languageCode = locale.languageCode
+
+        // Detect RTL using iOS Foundation API
+        val direction = NSLocale.characterDirectionForLanguage(languageCode)
+        val isRtl = direction == NSLocaleLanguageDirectionRightToLeft
+
+        return StateData.LocaleInfo(
+            languageCode = languageCode,
+            countryCode = locale.countryCode ?: "",
+            fullLocaleString = locale.localeIdentifier,
+            displayName = locale.displayNameForKey(
+                NSLocaleIdentifier,
+                locale.localeIdentifier
+            ) ?: locale.localeIdentifier,
+            isRTL = isRtl
+        )
+    }
+}


### PR DESCRIPTION
## Overview
This PR adds locale and RTL (Right-to-Left) detection capabilities to the KSensor library by implementing LocaleReceiver for both Android and iOS platforms.

## Changes
- **Android**: Adds `LocaleReceiver` class that monitors system locale changes and detects RTL layout direction
- **iOS**: Implements equivalent locale state management for iOS platform
- Updates `StateData.LocaleInfo` model to include language code, country code, locale string, display name, and RTL flag

## Features
- Detects locale changes via broadcast receiver on Android
- Supports Android API levels N+ using modern APIs with fallback for older versions
- Properly identifies RTL languages for correct layout handling
- Cross-platform implementation for both Android and iOS

## Related Issues
Closes #18