### PR TITLE
Add power save mode state to system plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Data Models (Wrapped in `KSensorResponse`):
 - Locale: `LocaleStatus(languageCode: String, countryCode: String, fullLocaleString: String, displayName: String, isRTL: Boolean)`
 - Screen: `ScreenStatus(isScreenOn: Boolean)`
 - Lock: `LockStatus(isDeviceLocked: Boolean)`
+- Power Save: `PowerSaveStatus(isPowerSaveMode: Boolean)`
 
 ## Bluetooth States Plugin
 

--- a/core/src/commonMain/kotlin/com/ksensor/core/model/StateData.kt
+++ b/core/src/commonMain/kotlin/com/ksensor/core/model/StateData.kt
@@ -12,6 +12,7 @@ enum class StateType {
     LOCALE,
     BATTERY,
     LOCK,
+    POWER_SAVE,
     BLE_CONNECTIONS,
     BLE_DISCOVERS
 }
@@ -34,6 +35,10 @@ sealed class StateData {
     data class LockStatus(
         val isDeviceLocked:Boolean
     ):StateData()
+
+    data class PowerSaveStatus(
+        val isPowerSaveMode: Boolean,
+    ) : StateData()
 
     data class CurrentActiveNetwork(val activeNetwork: ActiveNetwork) : StateData() {
         enum class ActiveNetwork {

--- a/plugins/states/system/src/androidMain/kotlin/com/ksensor/plugins/states/system/AndroidSystemPlugin.kt
+++ b/plugins/states/system/src/androidMain/kotlin/com/ksensor/plugins/states/system/AndroidSystemPlugin.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
+import android.os.PowerManager
 import com.ksensor.core.Permission
 import com.ksensor.core.PluginId
 import com.ksensor.core.StatePlugin
@@ -140,6 +141,26 @@ class AndroidSystemPlugin : SystemPlugin {
     }
 
     override fun lock(): StatePlugin<StateData.LockStatus> = lockPlugin
+
+    private val powerSaveFlow by lazy {
+        callbackFlow {
+            val receiver = PowerSaveReceiver { trySend(KSensorResponse(it)) }
+            context.registerReceiver(receiver, IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED))
+            trySend(KSensorResponse(PowerSaveReceiver.getCurrentStatus(context))) // initial value
+            awaitClose { context.unregisterReceiver(receiver) }
+        }.shareIn(scope, SharingStarted.WhileSubscribed(5000), 1)
+    }
+
+    private val powerSavePlugin = object : StatePlugin<StateData.PowerSaveStatus> {
+        override val id: PluginId = PluginId.SYSTEM
+        override val requiredPermissions: List<Permission> = emptyList()
+        override val currentState: KSensorResponse<StateData.PowerSaveStatus>
+            get() = KSensorResponse(PowerSaveReceiver.getCurrentStatus(context))
+
+        override fun observe(): Flow<KSensorResponse<StateData.PowerSaveStatus>> = powerSaveFlow
+    }
+
+    override fun powerSave(): StatePlugin<StateData.PowerSaveStatus> = powerSavePlugin
 }
 
 actual fun createSystemPlugin(): SystemPlugin = AndroidSystemPlugin()

--- a/plugins/states/system/src/androidMain/kotlin/com/ksensor/plugins/states/system/PowerSaveReceiver.kt
+++ b/plugins/states/system/src/androidMain/kotlin/com/ksensor/plugins/states/system/PowerSaveReceiver.kt
@@ -1,0 +1,22 @@
+package com.ksensor.plugins.states.system
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.PowerManager
+import com.ksensor.core.model.StateData
+
+internal class PowerSaveReceiver(private val onData: (StateData.PowerSaveStatus) -> Unit) : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (context == null) return
+        onData(getCurrentStatus(context))
+    }
+
+    companion object {
+        fun getCurrentStatus(context: Context): StateData.PowerSaveStatus {
+            val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+            return StateData.PowerSaveStatus(pm.isPowerSaveMode)
+        }
+    }
+}

--- a/plugins/states/system/src/commonMain/kotlin/com/ksensor/plugins/states/system/SystemPlugin.kt
+++ b/plugins/states/system/src/commonMain/kotlin/com/ksensor/plugins/states/system/SystemPlugin.kt
@@ -10,6 +10,7 @@ interface SystemPlugin : KSensorPlugin {
     fun locale(): StatePlugin<StateData.LocaleStatus>
     fun screen(): StatePlugin<StateData.ScreenStatus>
     fun lock(): StatePlugin<StateData.LockStatus>
+    fun powerSave(): StatePlugin<StateData.PowerSaveStatus>
 }
 
 expect fun createSystemPlugin(): SystemPlugin

--- a/plugins/states/system/src/commonTest/kotlin/com/ksensor/plugins/states/system/SystemPluginTest.kt
+++ b/plugins/states/system/src/commonTest/kotlin/com/ksensor/plugins/states/system/SystemPluginTest.kt
@@ -55,8 +55,16 @@ class FakeSystemPlugin : SystemPlugin {
         override val id: PluginId = PluginId.SYSTEM
         override val requiredPermissions: List<Permission> = emptyList()
         override val currentState: KSensorResponse<StateData.LockStatus> = TODO()
-        override fun observe(): Flow<KSensorResponse<StateData.LockStatus>> = 
+        override fun observe(): Flow<KSensorResponse<StateData.LockStatus>> =
             MutableSharedFlow<KSensorResponse<StateData.LockStatus>>().asTrackedFlow("lock")
+    }
+
+    override fun powerSave(): StatePlugin<StateData.PowerSaveStatus> = object : StatePlugin<StateData.PowerSaveStatus> {
+        override val id: PluginId = PluginId.SYSTEM
+        override val requiredPermissions: List<Permission> = emptyList()
+        override val currentState: KSensorResponse<StateData.PowerSaveStatus> = TODO()
+        override fun observe(): Flow<KSensorResponse<StateData.PowerSaveStatus>> =
+            MutableSharedFlow<KSensorResponse<StateData.PowerSaveStatus>>().asTrackedFlow("powerSave")
     }
 
     private fun <T> Flow<T>.asTrackedFlow(name: String): Flow<T> {
@@ -110,5 +118,14 @@ class SystemPluginTest {
         assertTrue(fake.activeObservers.contains("lock"))
         job.cancelAndJoin()
         assertFalse(fake.activeObservers.contains("lock"))
+    }
+
+    @Test
+    fun testPowerSave() = runBlocking {
+        val fake = FakeSystemPlugin()
+        val job = launch { fake.powerSave().observe().collect {} }
+        assertTrue(fake.activeObservers.contains("powerSave"))
+        job.cancelAndJoin()
+        assertFalse(fake.activeObservers.contains("powerSave"))
     }
 }

--- a/plugins/states/system/src/iosMain/kotlin/com/ksensor/plugins/states/system/IosSystemPlugin.kt
+++ b/plugins/states/system/src/iosMain/kotlin/com/ksensor/plugins/states/system/IosSystemPlugin.kt
@@ -98,6 +98,20 @@ class IosSystemPlugin : SystemPlugin {
             }
         }
     }
+
+    override fun powerSave(): StatePlugin<StateData.PowerSaveStatus> = object : StatePlugin<StateData.PowerSaveStatus> {
+        override val id: PluginId = PluginId.SYSTEM
+        override val requiredPermissions: List<Permission> = emptyList()
+        private val receiver = PowerSaveReceiver {}
+        override val currentState: KSensorResponse<StateData.PowerSaveStatus>
+            get() = KSensorResponse(receiver.getCurrentStatus())
+
+        override fun observe(): Flow<KSensorResponse<StateData.PowerSaveStatus>> = callbackFlow {
+            val obs = PowerSaveReceiver { trySend(KSensorResponse(it)) }
+            obs.register()
+            awaitClose { obs.unregister() }
+        }
+    }
 }
 
 actual fun createSystemPlugin(): SystemPlugin = IosSystemPlugin()

--- a/plugins/states/system/src/iosMain/kotlin/com/ksensor/plugins/states/system/PowerSaveReceiver.kt
+++ b/plugins/states/system/src/iosMain/kotlin/com/ksensor/plugins/states/system/PowerSaveReceiver.kt
@@ -1,0 +1,29 @@
+package com.ksensor.plugins.states.system
+
+import com.ksensor.core.model.StateData
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.Foundation.NSProcessInfo
+import platform.Foundation.NSProcessInfoPowerStateDidChangeNotification
+import platform.Foundation.lowPowerModeEnabled
+
+internal class PowerSaveReceiver(private val onData: (StateData.PowerSaveStatus) -> Unit) {
+    private var observer: platform.darwin.NSObjectProtocol? = null
+
+    private fun current() = StateData.PowerSaveStatus(NSProcessInfo.processInfo.lowPowerModeEnabled)
+
+    fun register() {
+        observer = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = NSProcessInfoPowerStateDidChangeNotification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue
+        ) { _ -> onData(current()) }
+        onData(current()) // initial value
+    }
+
+    fun unregister() {
+        observer?.let { NSNotificationCenter.defaultCenter.removeObserver(it) }
+    }
+
+    fun getCurrentStatus(): StateData.PowerSaveStatus = current()
+}


### PR DESCRIPTION
## Summary

Adds a `powerSave()` state to the **System States** plugin, mirroring the existing `battery()` / `lock()` states. No new module and no permissions on either platform.

New data type: `PowerSaveStatus(isPowerSaveMode: Boolean)`.

- **Android**: `PowerManager.isPowerSaveMode` + broadcast `PowerManager.ACTION_POWER_SAVE_MODE_CHANGED` (API 21+, minSdk 24).
- **iOS**: `NSProcessInfo.processInfo.lowPowerModeEnabled` + notification `NSProcessInfoPowerStateDidChangeNotification`.

## Changes

- `core/.../model/StateData.kt` — add `POWER_SAVE` to `StateType` and the `PowerSaveStatus` data class.
- `system/commonMain/SystemPlugin.kt` — add `powerSave()` to the interface.
- `system/androidMain` — new `PowerSaveReceiver` + flow/plugin wired into `AndroidSystemPlugin`.
- `system/iosMain` — new `PowerSaveReceiver` + plugin wired into `IosSystemPlugin`.
- `system/commonTest/SystemPluginTest.kt` — add `powerSave()` fake override and `testPowerSave()`.
- `README.md` — document the new data model.

## Verification

- `:plugins:states:system:compileKotlinIosSimulatorArm64` ✅
- `:plugins:states:system:compileAndroidMain` ✅
- `:plugins:states:system:assemble` ✅ (all iOS + Android targets)

Note: the `commonTest` `SystemPluginTest` suite fails on `iosSimulatorArm64Test` due to a pre-existing coroutine-timing issue in those tests (the same 5 existing tests fail on `main`); `testPowerSave` mirrors the existing tests exactly and behaves identically.

## Notes for maintainer (non-blocking)

- **Naming**: `powerSave()` / `PowerSaveStatus` / `StateType.POWER_SAVE` follow the existing style — happy to adjust.
- **Initial value on subscribe**: the Android flow emits the current state on subscribe (matching `battery`/`locale`). This is necessary because `ACTION_POWER_SAVE_MODE_CHANGED` is not a sticky broadcast.

Closes #30
